### PR TITLE
Fixes `load_dataset` method

### DIFF
--- a/iqadataset/load_dataset.py
+++ b/iqadataset/load_dataset.py
@@ -73,7 +73,7 @@ def prepare_dataset(name, dataset_root, attributes, download):
 
 
 def load_dataset(name, dataset_root="data", attributes=None, download=True):
-    csv_file = os.path.join("csv", name) + ".txt"
+    csv_file = os.path.join(os.path.dirname(__file__), "csv", name) + ".txt"
     attributes = prepare_dataset(name, dataset_root, attributes, download)
 
     return IQADataset(csv_file, name, dataset_root, attributes)


### PR DESCRIPTION
`load_dataset` was broken as it could not locate the csv files stored in the module, this fixes that by replicating the behavior from the `load_dataset_pytorch` method.

To replicate, try to install the package from PyPI or git and then run this snippet:

```python
from iqadataset import load_dataset

dataset = load_dataset(
    "LIVE", 
    dataset_root="data", 
    attributes=["dis_img_path", "dis_type", "score"], 
    download=True,
)
```

This would fail with an error previously but works as expected now.